### PR TITLE
Open JSON files in binary mode

### DIFF
--- a/itch_dl/handlers.py
+++ b/itch_dl/handlers.py
@@ -150,7 +150,7 @@ def get_jobs_for_itch_url(url: str, client: ItchApiClient) -> List[str]:
 
 def get_jobs_for_path(path: str) -> List[str]:
     try:  # Game Jam Entries JSON?
-        with open(path) as f:
+        with open(path, "rb") as f:
             json_data = json.load(f)
 
         if not isinstance(json_data, dict):


### PR DESCRIPTION
This avoids any encoding errors caused by JSON files containing non-ASCII characters (e.g. emojis).

I'm not sure if this encoding issue occurs just on Windows (the corresponding stack trace stems from CP-1252), but I think opening the file in binary mode is the right way to go anyway.

For reference, here's the traceback logged when trying to load a file which has some emojis in the JSON:
```
Traceback (most recent call last):
  File "itch-dl\venv\Scripts\itch-dl", line 5, in <module>
    run()
  File "itch-dl\itch_dl\cli.py", line 60, in run
    jobs = get_jobs_for_url_or_path(args.url_or_path, settings)
  File "itch-dl\itch_dl\handlers.py", line 191, in get_jobs_for_url_or_path
    return get_jobs_for_path(path_or_url)
  File "itch-dl\itch_dl\handlers.py", line 154, in get_jobs_for_path
    json_data = json.load(f)
  File "C:\Python310\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 22612: character maps to <undefined>
```