### PR TITLE
Update infobox.py for strptime() error

### DIFF
--- a/itch_dl/infobox.py
+++ b/itch_dl/infobox.py
@@ -35,7 +35,7 @@ def parse_date_block(td: BeautifulSoup) -> Optional[datetime]:
 
     date_str, time_str = abbr['title'].split('@')
     date = datetime.strptime(date_str.strip(), "%d %B %Y")
-    time = datetime.strptime(time_str.strip(), "%H:%M")
+    time = datetime.strptime(time_str.strip(), "%H:%M UTC")
     return datetime(date.year, date.month, date.day, time.hour, time.minute)
 
 


### PR DESCRIPTION
Fixes:

File "/usr/lib/python3.11/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
ValueError: unconverted data remains:  UTC